### PR TITLE
upgrade promise dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "concat-stream": ">=1.2.1 <2",
-    "promise": ">=3 <6"
+    "promise": ">=3 <8"
   },
   "devDependencies": {
     "through": "~2.3.1",


### PR DESCRIPTION
Promise 8.0.0 is compatible with the API subset this uses, and 6.x is getting a lil ancient.